### PR TITLE
Skip ssl cert validation

### DIFF
--- a/FunctionAppTools/FunctionAppTools/Functions/Public/Get-Swagger.ps1
+++ b/FunctionAppTools/FunctionAppTools/Functions/Public/Get-Swagger.ps1
@@ -23,8 +23,30 @@ function Get-Swagger{
     if($AuthenticationKeyRequired.IsPresent) {
         $MasterKey = Get-FunctionAppHostKey -ResourceGroupName $ResourceGroupName -FunctionAppName $FunctionAppName -FunctionAppDomain $FunctionAppDomain
     }
-    
+
     $Uri = "https://$FunctionAppName.$FunctionAppDomain/api/$ApiResourceName/api-definition?code=$($MasterKey)"
-    $Swagger = (Invoke-WebRequest -Uri $Uri -UseBasicParsing).Content
+
+
+    $Swagger = ""
+
+    if($PSVersionTable.PSVersion.Major -eq 5) {
+        add-type @"
+        using System.Net;
+        using System.Security.Cryptography.X509Certificates;
+        public class TrustAllCertsPolicy : ICertificatePolicy {
+            public bool CheckValidationResult(
+                ServicePoint srvPoint, X509Certificate certificate,
+                WebRequest request, int certificateProblem) {
+                return true;
+            }
+        }
+"@    
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy        
+
+        $Swagger = (Invoke-WebRequest -Uri $Uri -UseBasicParsing).Content
+    } else {
+        $Swagger = (Invoke-WebRequest -Uri $Uri -UseBasicParsing -SkipCertificateCheck).Content
+    }
+    
     $Swagger
 }


### PR DESCRIPTION
Now that we have a self-signed cert apim,  we need to skip validating it.  
This has to be done in a powershell-independant way, hence the complexity here